### PR TITLE
improvements

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -301,3 +301,25 @@ void CPlayer::TryRespawn()
 	m_pCharacter->Spawn(this, SpawnPos);
 	GameServer()->CreatePlayerSpawn(SpawnPos);
 }
+
+void CPlayer::updateInterpolatedMouseMaxDist(float aimDist)
+{
+    const int Timeout = 3 /*seconds*/;
+    
+    if(this->MouseMaxDist < aimDist)
+    {
+        this->MouseMaxDist = aimDist;
+    }
+    
+    if(abs(this->MouseMaxDist - aimDist) <= 1.0)
+    {
+        // ok, our value still seems to be up to date
+        this->LastMouseMaxDistTick = Server()->Tick();
+    }
+    
+    if((Server()->Tick() - this->LastMouseMaxDistTick) > Server()->TickSpeed() * Timeout)
+    {
+        // reset
+        this->MouseMaxDist = 0.0f;
+    }
+}

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -99,10 +99,24 @@ public:
 	} m_Latency;
 
 	// RajhCheatDetector
-	int Warnings;
-	int LastWarn;
-	std::valarray<int> LastFireTick;
-	unsigned int LastFireIdx;
+        
+    // no. of warnings this player received
+    int Warnings;
+
+    // contains server->Tick() when player received past warning
+    int LastWarn;
+
+    // array of ticks, add one tick at LastFireIdx whenever a player shoots
+    std::valarray<int> LastFireTick;
+    unsigned int LastFireIdx;
+
+    // holds the maximum distance a player aimed away from himself
+    float MouseMaxDist;
+
+    // holds server->Tick() of the last time this player pointed at MouseMaxDist
+    int LastMouseMaxDistTick;
+
+    void updateInterpolatedMouseMaxDist(float aimDist);
 
 private:
 	CCharacter *m_pCharacter;

--- a/src/game/server/rcd.cpp
+++ b/src/game/server/rcd.cpp
@@ -179,10 +179,10 @@ bool RajhCheatDetector::CheckInputPos(CPlayer *Player, int Victim, warning_t& wa
 		return true;
 	}*/
     
-    /* This might become necessary in the future, see my explanation in PR
-    float interpolatedMouseMaxDist; // << TODO: somehow interpolate that value for every player
+    // This might become necessary in the future, see my explanation in PR
+    //float interpolatedMouseMaxDist; // << TODO: somehow interpolate that value for every player
     float aimDistance = distance(TargetPos, CPlayer->m_Pos);
-    if(interpolatedMouseMaxDist-2 <= aimDistance && aimDistance <= interpolatedMouseMaxDist+2)
+    /*if(interpolatedMouseMaxDist-2 <= aimDistance && aimDistance <= interpolatedMouseMaxDist+2)
     {
       str_format(aBuf, sizeof(aBuf), "'%s' aimed at cl_mouse_max_distance +- 2, ignoring", Player->Server()->ClientName(Player->GetCID()));
       Player->GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "rcd", aBuf);
@@ -201,7 +201,7 @@ bool RajhCheatDetector::CheckInputPos(CPlayer *Player, int Victim, warning_t& wa
 		return true;
 	}
 
-	str_format(aBuf, sizeof(aBuf), "'%s' aimed exactly at '%s' position (dist(TargetPos,Victim)==%f)", Player->Server()->ClientName(Player->GetCID()), Player->Server()->ClientName(Victim), DistanceAimToVictim);
+	str_format(aBuf, sizeof(aBuf), "'%s' aimed exactly at '%s' position (dist(TargetPos,Victim)==%f) ; (dist(TargetPos,Player)==%f)", Player->Server()->ClientName(Player->GetCID()), Player->Server()->ClientName(Victim), DistanceAimToVictim, aimDistance);
 	Player->GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "rcd", aBuf);
 
     // if DistanceAimToVictim == 1, player will get 7 warnings

--- a/src/game/server/rcd.cpp
+++ b/src/game/server/rcd.cpp
@@ -29,6 +29,18 @@ void RajhCheatDetector::OnFire(CPlayer * Player)
 {
 	if(CheckFastFire(Player))
 		AddWarning(Player, 1);
+    
+    
+    CCharacter *CPlayer;
+    if(!(CPlayer = Player->GameServer()->GetPlayerChar(Player->GetCID())))
+            return;
+
+    vec2 Target = vec2(CPlayer->m_LatestInput.m_TargetX, CPlayer->m_LatestInput.m_TargetY);
+    vec2 TargetPos = CPlayer->m_Pos + Target;
+
+    // on every input, store and if necessary update CPlayers interpolated cl_mouse_max_distance
+    float aimDistance = distance(TargetPos, CPlayer->m_Pos);
+    Player->updateInterpolatedMouseMaxDist(aimDistance);
 }
 
 void RajhCheatDetector::OnHit(CPlayer * Player, int Victim)
@@ -180,7 +192,7 @@ bool RajhCheatDetector::CheckInputPos(CPlayer *Player, int Victim, warning_t& wa
 	}*/
     
     // This might become necessary in the future, see my explanation in PR
-    float interpolatedMouseMaxDist = CPlayer->getInterpolatedMouseMaxDist();
+    float interpolatedMouseMaxDist = Player->MouseMaxDist;
     float aimDistance = distance(TargetPos, CPlayer->m_Pos);
     const int8_t Tolerance = 2;
     if(interpolatedMouseMaxDist-Tolerance <= aimDistance && aimDistance <= interpolatedMouseMaxDist+Tolerance)

--- a/src/game/server/rcd.cpp
+++ b/src/game/server/rcd.cpp
@@ -168,7 +168,8 @@ bool RajhCheatDetector::CheckInputPos(CPlayer *Player, int Victim, warning_t& wa
 	if(DistanceAimToVictim >= WhatICallClose)
 		return false;
 
-	// Ignore if distance between target and player <= 50
+    /* creates a dead zone at <= 50, uncomment that for now. if necessary will be superseeded by the check below
+    // Ignore if distance between target and player <= 50
 	// cl_mouse_max_distance <= 50 can cause false positives
 	if(distance(TargetPos, CPlayer->m_Pos) <= 50.f) {
 		str_format(aBuf, sizeof(aBuf), "'%s' aimed at '%s' position from close distance, ignoring", Player->Server()->ClientName(Player->GetCID()), Player->Server()->ClientName(Victim));
@@ -176,11 +177,12 @@ bool RajhCheatDetector::CheckInputPos(CPlayer *Player, int Victim, warning_t& wa
         
         warnLevelOut = 0;
 		return true;
-	}
+	}*/
     
-    /*float interpolatedMouseMaxDist = 50;
+    /* This might become necessary in the future, see my explanation in PR
+    float interpolatedMouseMaxDist; // << TODO: somehow interpolate that value for every player
     float aimDistance = distance(TargetPos, CPlayer->m_Pos);
-    if(interpolatedMouseMaxDist -2 <= aimDistance && aimDistance <= interpolatedMouseMaxDist +2)
+    if(interpolatedMouseMaxDist-2 <= aimDistance && aimDistance <= interpolatedMouseMaxDist+2)
     {
       str_format(aBuf, sizeof(aBuf), "'%s' aimed at cl_mouse_max_distance +- 2, ignoring", Player->Server()->ClientName(Player->GetCID()));
       Player->GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "rcd", aBuf);

--- a/src/game/server/rcd.cpp
+++ b/src/game/server/rcd.cpp
@@ -180,16 +180,17 @@ bool RajhCheatDetector::CheckInputPos(CPlayer *Player, int Victim, warning_t& wa
 	}*/
     
     // This might become necessary in the future, see my explanation in PR
-    //float interpolatedMouseMaxDist; // << TODO: somehow interpolate that value for every player
+    float interpolatedMouseMaxDist = CPlayer->getInterpolatedMouseMaxDist();
     float aimDistance = distance(TargetPos, CPlayer->m_Pos);
-    /*if(interpolatedMouseMaxDist-2 <= aimDistance && aimDistance <= interpolatedMouseMaxDist+2)
+    const int8_t Tolerance = 2;
+    if(interpolatedMouseMaxDist-Tolerance <= aimDistance && aimDistance <= interpolatedMouseMaxDist+Tolerance)
     {
-      str_format(aBuf, sizeof(aBuf), "'%s' aimed at cl_mouse_max_distance +- 2, ignoring", Player->Server()->ClientName(Player->GetCID()));
+      str_format(aBuf, sizeof(aBuf), "'%s' aimed at mouse_max_dist +- %d, ignoring (cl_mouse_max_distance == %f)", Player->Server()->ClientName(Player->GetCID()), Tolerance, interpolatedMouseMaxDist);
       Player->GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "rcd", aBuf);
 
       warnLevelOut = 0;
       return true;
-    }*/
+    }
 
 	// Ignore shoots at non-moving target
 	// Newbies can be accidentally banned for shooting afk players because of placing cursor on them directly.

--- a/src/game/server/rcd.hpp
+++ b/src/game/server/rcd.hpp
@@ -1,6 +1,8 @@
 #ifndef GAME_SERVER_RCD_H
 #define GAME_SERVER_RCD_H
 
+typedef int warning_t;
+
 class RajhCheatDetector
 {
 public:
@@ -15,7 +17,7 @@ private:
        static void CheckWarnings(CPlayer * Player);
        static void AddWarning(CPlayer * Player, int amount = 1);
        static bool CheckFastChange(CPlayer * Player);
-       static bool CheckInputPos(CPlayer * Player, int Victim);
+       static bool CheckInputPos(CPlayer * Player, int Victim, warning_t& warnLevelOut);
        static bool CheckReflex(CPlayer * Player, int Victim);
        static bool CheckFastFire(CPlayer * Player);
 };


### PR DESCRIPTION
ok, what I did is to let the warning level of `CheckInputPos()` depend on the accuracy a player aims another. if he aims on a player with a distance of 8.f, he will score no warnings, if he does exactly aim on him, he'll score 8 warnings. (the same idea might be applicable to `CheckReflex()`)

by that I also hope to avoid that players with `cl_mouse_max_dist <= 50` get warnings. When Nibiru tested that, maybe the distance to the other player was around 8, causing him to score 4 warnings every time. now he shouldn't score anything. Please ask him to test it again. If it does not work as expected, well have to try another way: these false positives might occur, when a player aims at `cl_mouse_max_dist` and shoots when another player just entered that section so that:

`distance(Player,Victim) == distance(Player, Player.TargetPos) == cl_mouse_max_dist`

then we can try to ignore that area around `cl_mouse_max_dist+-2` (see [rcd.cpp:183](https://github.com/derselbst/teeworlds/blob/85dbf32017fa9de3d4f05dfbb262de62821c3112/src/game/server/rcd.cpp#L183)). however, retrieving / interpolating `cl_mouse_max_dist` at server side is a bit tricky, since it might be changed during gameplay, so I postponed that check, hoping that my first idea works ;)

I hope it builds, and sorry for screwing up your formatting; github editor prefers spaces rather than tabs
